### PR TITLE
Modal ProgressDialog: restore focus to owner

### DIFF
--- a/src/Ookii.Dialogs.Wpf/NativeMethods.cs
+++ b/src/Ookii.Dialogs.Wpf/NativeMethods.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -57,6 +57,9 @@ namespace Ookii.Dialogs.Wpf
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
         public static extern IntPtr GetActiveWindow();
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
+        public static extern bool EnableWindow(IntPtr hwnd, bool bEnable);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
         public static extern int GetWindowThreadProcessId(IntPtr hWnd, out int lpdwProcessId);

--- a/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
@@ -55,6 +55,7 @@ namespace Ookii.Dialogs.Wpf
         private SafeModuleHandle _currentAnimationModuleHandle;
         private bool _cancellationPending;
         private int _percentProgress;
+        private IntPtr _ownerHandle;
 
         /// <summary>
         /// Event raised when the dialog is displayed.
@@ -756,6 +757,7 @@ namespace Ookii.Dialogs.Wpf
             if( !MinimizeBox )
                 flags |= Ookii.Dialogs.Wpf.Interop.ProgressDialogFlags.NoMinimize;
 
+            _ownerHandle = owner;
             _dialog.StartProgressDialog(owner, null, flags, IntPtr.Zero);
             _backgroundWorker.RunWorkerAsync(argument);
         }
@@ -775,6 +777,9 @@ namespace Ookii.Dialogs.Wpf
                 _currentAnimationModuleHandle.Dispose();
                 _currentAnimationModuleHandle = null;
             }
+
+            if (_ownerHandle != IntPtr.Zero)
+                NativeMethods.EnableWindow(_ownerHandle, true);
 
             OnRunWorkerCompleted(new RunWorkerCompletedEventArgs((!e.Cancelled && e.Error == null) ? e.Result : null, e.Error, e.Cancelled));
         }


### PR DESCRIPTION
When using a modal ProgressDialog (with ShowDialog()) the focus does not return to the owner window.
Additionally, when running under Wine emulation on Linux, the window becomes unresponsive as it remains in disabled state.
This patch restores the behavior by calling user32.dll EnableWindow on the owner handle

Also solves issues like this:
https://stackoverflow.com/questions/21920645/ookii-dialogs-progressdialog-in-modal-style-doesnt-focus-owner-window-after-com
